### PR TITLE
Enable grape-rabl to render correct rabl version of the object

### DIFF
--- a/lib/grape-rabl/formatter.rb
+++ b/lib/grape-rabl/formatter.rb
@@ -28,9 +28,9 @@ module Grape
 
           def view_path(template)
             if template.split(".")[-1] == "rabl"
-              File.join(env['api.tilt.root'], template)
+              File.join(env['api.tilt.root'], env['api.version'].to_s, template)
             else
-              File.join(env['api.tilt.root'], (template + ".rabl"))
+              File.join(env['api.tilt.root'], env['api.version'].to_s, (template + ".rabl"))
             end
           end
 


### PR DESCRIPTION
Add the version to the template file path so that the correct version of the rabl is rendered.

``` ruby
class API::V1::Users < Grape::API
  version 'v1', using: :header, vendor: 'leeo'
  format :json
  formatter :json, Grape::Formatter::Rabl
end

class API::V2::Users < Grape::API
  version 'v2', using: :header, vendor: 'leeo'
  format :json
  formatter :json, Grape::Formatter::Rabl
end

class Application < Rails::Application
    config.middleware.use(Rack::Config) do |env|
        env['api.tilt.root'] = Rails.root.join "app", "views", "api"
    end
end
```

With that setup, the template path will now contain the env['api.version']. If there isn't a version specified, then the original path will work fine.

I think the specs will have to include these use cases of versioning.
