### PR TITLE
Use template from endpoint declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ class UserAPI < Grape::API
     end
   end
 
+  get '/admin/:id', :rabl => 'admin' do
+    @user = User.find(params[:id])
+
+    # use rabl with 'super_admin.rabl'
+    render rabl: 'super_admin' if @user.super_admin?
+    # when render method has not been used use template from endpoint definition
+  end
+
   # use rabl with 'user_history.rabl' template
   get '/user/:id/history', :rabl => 'user_history' do
     @history = User.find(params[:id]).history

--- a/spec/grape_rabl_spec.rb
+++ b/spec/grape_rabl_spec.rb
@@ -52,6 +52,12 @@ describe Grape::Rabl do
           render rabl: 'admin'
         end
 
+        subject.get('/admin/:id', rabl: 'user') do
+          @user = OpenStruct.new(name: 'LTe')
+
+          render rabl: 'admin' if params[:id] == '1'
+        end
+
         subject.get('/home-detail', rabl: 'user') do
           @user = OpenStruct.new(name: 'LTe')
           render rabl: 'admin', locals: { details: 'amazing detail' }
@@ -69,7 +75,17 @@ describe Grape::Rabl do
 
       it 'renders template passed as argument to render method' do
         get('/home')
-        last_response.body.should == '{"admin":{"name":"LTe"}}'
+        parsed_response.should == JSON.parse('{"admin":{"name":"LTe"}}')
+      end
+
+      it 'renders admin template' do
+        get('/admin/1')
+        parsed_response.should == JSON.parse('{"admin":{"name":"LTe"}}')
+      end
+
+      it 'renders user template' do
+        get('/admin/2')
+        parsed_response.should == JSON.parse('{"user":{"name":"LTe","project":null}}')
       end
 
       it 'renders template passed as argument to render method with locals' do


### PR DESCRIPTION
When `render` when the render method has not been executed, template
from endpoint declaration should be used.

Related: https://github.com/LTe/grape-rabl/issues/29
