### PR TITLE
use tilt_options and path as cache key for templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-2.2.10
+  - rbx-2
 
 matrix:
   allow_failures:
     - rvm: jruby-19mode
     - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: rbx-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Next
 
+* Fix template caching for multiple formats. [#43](https://github.com/ruby-grape/grape-rabl/pull/43) [@kushkella](https://github.com/kushkella)
 * Your contribution here.
 
 #### v0.4.1

--- a/lib/grape-rabl/formatter.rb
+++ b/lib/grape-rabl/formatter.rb
@@ -67,7 +67,7 @@ module Grape
 
       def tilt_template(template)
         if Grape::Rabl.configuration.cache_template_loading
-          Grape::Rabl::Formatter.tilt_cache.fetch(template) { ::Tilt.new(view_path(template), tilt_options) }
+          Grape::Rabl::Formatter.tilt_cache.fetch(tilt_cache_key(template)) { ::Tilt.new(view_path(template), tilt_options) }
         else
           ::Tilt.new(view_path(template), tilt_options)
         end
@@ -80,10 +80,14 @@ module Grape
       def layout_template
         layout_path = view_path(env['api.tilt.layout'] || 'layouts/application')
         if Grape::Rabl.configuration.cache_template_loading
-          Grape::Rabl::Formatter.tilt_cache.fetch(layout_path) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
+          Grape::Rabl::Formatter.tilt_cache.fetch(tilt_cache_key(layout_path)) { ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path) }
         else
           ::Tilt.new(layout_path, tilt_options) if File.exist?(layout_path)
         end
+      end
+
+      def tilt_cache_key(path)
+        Digest::MD5.hexdigest("#{path}#{tilt_options}")
       end
     end
   end


### PR DESCRIPTION
We have APIs that respond to multiple formats, and if we enable `cache_template_loading` it is stuck with the first format that it serves. The reason was that the cache key was same for all formats and options although it only supported one format.